### PR TITLE
Write ~/.saferc and ~/.svtoken files for operators

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Improvements
+
+- Blacksmith now creates a `~/.saferc` file, for operators to use,
+  and a `~/.svtoken` file, for Spruce to fall back on.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,4 +1,13 @@
 # Improvements
 
-- Blacksmith now creates a `~/.saferc` file, for operators to use,
-  and a `~/.svtoken` file, for Spruce to fall back on.
+- Blacksmith now creates the following files, after it has
+  initiaized or unsealed the local Blacksmith Vault:
+
+    1. `$BLACKSMITH_OPER_HOME/.saferc` for `safe` to use
+    2. `$BLACKSMITH_OPER_HOME/.svtoken` for `spruce` to use
+    3. `$BLACKSMITH_OPER_HOME/.vault-token` for `vault` to use
+
+  If the `BLACKSMITH_OPER_HOME` environment variable is set.
+  This helps to keep our developers from overwriting real files,
+  while still allowing the BOSH release of Blacksmith to provide
+  an operator-friendly environment.


### PR DESCRIPTION
Once blacksmith has hooked back up to the Vault, it can now also create
~/.saferc and ~/.svtoken files for operators to use when they `bosh ssh`
into the Blacksmith director.