### PR TITLE
Regularly get a new BOSH token

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,6 +189,7 @@ func main() {
 	for {
 		select {
 		case <-BoshMaintenanceLoop.C:
+			bosh.refreshClient()
 			vaultDB, err := vault.getVaultDB()
 			if err != nil {
 				l.Error("error grabbing vaultdb for debugging: %s", err)


### PR DESCRIPTION
Hi there

I'd like to propose this change to prevent the broker from trying to make requests to the BOSH director with an invalid UAA token, as described here: https://github.com/blacksmith-community/blacksmith-boshrelease/issues/13

We see this issue regularly, and at the moment we resolve it temporarily by doing a `bosh restart` of blacksmith. It would be nicer if the broker's infinite loop just went out and regularly obtained a fresh token.

Apologies in advance for any mistakes here - I'm a PaaS person rather than an app developer!