### PR TITLE
Backport Shareable flag

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -47,6 +47,11 @@ plan disks, and deploy the data + code to a new deployment.
 For service decommission, the broker simply deletes the BOSH
 deployment for the service UUID.
 
+Shareable services is a flag in the Catalog API used by the CF
+`create-service-broker` and `update-service-broker` commands. By
+default, this is false.  The flag can be set in the config to
+update the Catalog to advertise services as shareable.
+
 
 
 Deploying Blacksmith

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,7 @@
+# Improvements
+
+- Blacksmith can now advertise shareable services in the Catalog. Option
+  `shareable` flag can be added and if set to `true` to update the broker
+  catalog when registered or updated.  Otherwise blacksmith follows the old
+  behavior of not advertising as shareable.
+  https://docs.cloudfoundry.org/services/enable-sharing.html

--- a/config.go
+++ b/config.go
@@ -9,12 +9,13 @@ import (
 )
 
 type Config struct {
-	Broker  BrokerConfig `yaml:"broker"`
-	Vault   VaultConfig  `yaml:"vault"`
-	BOSH    BOSHConfig   `yaml:"bosh"`
-	Debug   bool         `yaml:"debug"`
-	WebRoot string       `yaml:"web-root"`
-	Env     string       `yaml:"env"`
+	Broker    BrokerConfig `yaml:"broker"`
+	Vault     VaultConfig  `yaml:"vault"`
+	BOSH      BOSHConfig   `yaml:"bosh"`
+	Debug     bool         `yaml:"debug"`
+	WebRoot   string       `yaml:"web-root"`
+	Env       string       `yaml:"env"`
+	Shareable bool         `yaml:"shareable"`
 }
 
 type BrokerConfig struct {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ func main() {
 		Debugging = true
 	}
 
+	if config.Shareable {
+		Shareable = true
+	}
+
 	l := Logger.Wrap("*")
 
 	bind := fmt.Sprintf(":%s", config.Broker.Port)

--- a/services.go
+++ b/services.go
@@ -29,8 +29,8 @@ type Service struct {
 	Bindable    bool     `yaml:"bindable" json:"bindable"`
 	Tags        []string `yaml:"tags" json:"tags"`
 	Limit       int      `yaml:"limit" json:"limit"`
-
-	Plans []Plan `yaml:"plans" json:"plans"`
+	Shareable   bool     `yaml:"shareable" json:"shareable"`
+	Plans       []Plan   `yaml:"plans" json:"plans"`
 }
 
 var ValidName *regexp.Regexp
@@ -213,11 +213,14 @@ func ReadServices(dirs ...string) ([]Service, error) {
 func Catalog(ss []Service) []brokerapi.Service {
 	bb := make([]brokerapi.Service, len(ss))
 	for i, s := range ss {
+		var md brokerapi.ServiceMetadata
 		bb[i].ID = s.ID
 		bb[i].Name = s.Name
 		bb[i].Description = s.Description
 		bb[i].Bindable = s.Bindable
 		bb[i].Tags = make([]string, len(s.Tags))
+		bb[i].Metadata = &md
+		bb[i].Metadata.Shareable = brokerapi.FreeValue(s.Shareable)
 		copy(bb[i].Tags, s.Tags)
 		bb[i].Plans = make([]brokerapi.ServicePlan, len(s.Plans))
 		for j, p := range s.Plans {

--- a/services.go
+++ b/services.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var Shareable bool
+
 type Plan struct {
 	ID          string `yaml:"id" json:"id"`
 	Name        string `yaml:"name" json:"name"`
@@ -37,6 +39,7 @@ var ValidName *regexp.Regexp
 
 func init() {
 	ValidName = regexp.MustCompile("^[a-zA-Z0-9-]+$")
+	Shareable = false
 }
 
 func CheckNames(names ...string) error {
@@ -220,7 +223,7 @@ func Catalog(ss []Service) []brokerapi.Service {
 		bb[i].Bindable = s.Bindable
 		bb[i].Tags = make([]string, len(s.Tags))
 		bb[i].Metadata = &md
-		bb[i].Metadata.Shareable = brokerapi.FreeValue(s.Shareable)
+		bb[i].Metadata.Shareable = brokerapi.FreeValue(Shareable)
 		copy(bb[i].Tags, s.Tags)
 		bb[i].Plans = make([]brokerapi.ServicePlan, len(s.Plans))
 		for j, p := range s.Plans {

--- a/vendor/github.com/pivotal-cf/brokerapi/catalog.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/catalog.go
@@ -45,6 +45,7 @@ type ServiceMetadata struct {
 	ProviderDisplayName string `json:"providerDisplayName,omitempty"`
 	DocumentationUrl    string `json:"documentationUrl,omitempty"`
 	SupportUrl          string `json:"supportUrl,omitempty"`
+	Shareable           *bool  `json:"shareable,omitempty"`
 }
 
 func FreeValue(v bool) *bool {


### PR DESCRIPTION
This update backports the brokerapi to support the shareable flag for service sharing

https://docs.cloudfoundry.org/services/enable-sharing.html

By default, it is false which matched the previous release (unshareable). When the setting is passed in and set to true, services will advertise as shareable.