### PR TITLE
Support CF create-service parameters

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -52,7 +52,12 @@ Shareable services is a flag in the Catalog API used by the CF
 default, this is false.  The flag can be set in the config to
 update the Catalog to advertise services as shareable.
 
-
+If you create a service with the `-c PARAMETERS_AS_JSON` containing
+service-specific configuration parameters, Blacksmith will merge this
+into the manifest under `params:` as well as write a YAML and JSON
+file of the parameters to `/var/vcap/data/blacksmith/INSTANCE_ID.yml`
+and `/var/vcap/data/blacksmith/INSTANCE_ID.json` the init script can
+use.
 
 Deploying Blacksmith
 --------------------

--- a/NOTES.md
+++ b/NOTES.md
@@ -54,7 +54,7 @@ update the Catalog to advertise services as shareable.
 
 If you create a service with the `-c PARAMETERS_AS_JSON` containing
 service-specific configuration parameters, Blacksmith will merge this
-into the manifest under `params:` as well as write a YAML and JSON
+into the manifest under `meta.params:` as well as write a YAML and JSON
 file of the parameters to `/var/vcap/data/blacksmith/INSTANCE_ID.yml`
 and `/var/vcap/data/blacksmith/INSTANCE_ID.json` the init script can
 use.

--- a/broker.go
+++ b/broker.go
@@ -3,13 +3,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"time"
-  "io/ioutil"
 
 	"github.com/cloudfoundry-community/gogobosh"
 	"github.com/pivotal-cf/brokerapi"
-  "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type Broker struct {
@@ -24,28 +24,28 @@ type Job struct {
 	IPs  []string
 }
 
-func WriteDataFile(instanceID string, data []byte) (error) {
-  filepath := "/var/vcap/data/blacksmith/"
-  filename := filepath + instanceID + ".json"
-  err := ioutil.WriteFile(filename, data, 0644)
-  return err
+func WriteDataFile(instanceID string, data []byte) error {
+	filepath := "/var/vcap/data/blacksmith/"
+	filename := filepath + instanceID + ".json"
+	err := ioutil.WriteFile(filename, data, 0644)
+	return err
 }
 
-func WriteYamlFile(instanceID string, data []byte) (error) {
+func WriteYamlFile(instanceID string, data []byte) error {
 	l := Logger.Wrap("%s", instanceID)
-  m := make(map[interface{}]interface{})
-  err := yaml.Unmarshal(data, &m)
-  if err != nil {
-    l.Debug("Error unmarshalling data: %s, %s", err, data)
-  }
-  b, err := yaml.Marshal(m)
-  if err != nil {
-    l.Debug("Error marshalling data: %s, %s", err, m)
-  }
-  filepath := "/var/vcap/data/blacksmith/"
-  filename := filepath + instanceID + ".yml"
-  err = ioutil.WriteFile(filename, b, 0644)
-  return err
+	m := make(map[interface{}]interface{})
+	err := yaml.Unmarshal(data, &m)
+	if err != nil {
+		l.Debug("Error unmarshalling data: %s, %s", err, data)
+	}
+	b, err := yaml.Marshal(m)
+	if err != nil {
+		l.Debug("Error marshalling data: %s, %s", err, m)
+	}
+	filepath := "/var/vcap/data/blacksmith/"
+	filename := filepath + instanceID + ".yml"
+	err = ioutil.WriteFile(filename, b, 0644)
+	return err
 }
 
 func (b Broker) FindPlan(serviceID string, planID string) (Plan, error) {
@@ -109,15 +109,15 @@ func (b *Broker) Provision(instanceID string, details brokerapi.ProvisionDetails
 
 	defaults := make(map[interface{}]interface{})
 	//TODO parse params from json to yaml
-  l.Debug("Param raw data: %s", details.RawParameters)
-  err = WriteDataFile(instanceID, details.RawParameters)
-  if err != nil {
-    l.Debug("WriteDataFile write failed with '%s'", err)
-  }
-  err = WriteYamlFile(instanceID, details.RawParameters)
-  if err != nil {
-    l.Debug("WriteYamlFile write failed with '%s'", err)
-  }
+	l.Debug("Param raw data: %s", details.RawParameters)
+	err = WriteDataFile(instanceID, details.RawParameters)
+	if err != nil {
+		l.Debug("WriteDataFile write failed with '%s'", err)
+	}
+	err = WriteYamlFile(instanceID, details.RawParameters)
+	if err != nil {
+		l.Debug("WriteYamlFile write failed with '%s'", err)
+	}
 	params := make(map[interface{}]interface{})
 	defaults["name"] = plan.ID + "-" + instanceID
 
@@ -139,8 +139,8 @@ func (b *Broker) Provision(instanceID string, details brokerapi.ProvisionDetails
 		return spec, fmt.Errorf("BOSH service deployment initial setup failed")
 	}
 
-  l.Debug("Provision defaults: %s", defaults)
-  l.Debug("Provision params: %s", params)
+	l.Debug("Provision defaults: %s", defaults)
+	l.Debug("Provision params: %s", params)
 
 	l.Debug("generating manifest for service deployment")
 	manifest, err := GenManifest(plan, defaults, wrap("meta.params", params))

--- a/broker.go
+++ b/broker.go
@@ -108,7 +108,6 @@ func (b *Broker) Provision(instanceID string, details brokerapi.ProvisionDetails
 	}
 
 	defaults := make(map[interface{}]interface{})
-	//TODO parse params from json to yaml
 	l.Debug("Param raw data: %s", details.RawParameters)
 	err = WriteDataFile(instanceID, details.RawParameters)
 	if err != nil {
@@ -119,6 +118,10 @@ func (b *Broker) Provision(instanceID string, details brokerapi.ProvisionDetails
 		l.Debug("WriteYamlFile write failed with '%s'", err)
 	}
 	params := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(details.RawParameters, &params)
+	if err != nil {
+		l.Debug("Error unmarshalling params: %s, %s", err, details.RawParameters)
+	}
 	defaults["name"] = plan.ID + "-" + instanceID
 
 	l.Debug("querying BOSH director for director UUID")

--- a/broker.go
+++ b/broker.go
@@ -25,8 +25,7 @@ type Job struct {
 }
 
 func WriteDataFile(instanceID string, data []byte) error {
-	filepath := "/var/vcap/data/blacksmith/"
-	filename := filepath + instanceID + ".json"
+	filename := GetWorkDir() + instanceID + ".json"
 	err := ioutil.WriteFile(filename, data, 0644)
 	return err
 }
@@ -42,8 +41,7 @@ func WriteYamlFile(instanceID string, data []byte) error {
 	if err != nil {
 		l.Debug("Error marshalling data: %s, %s", err, m)
 	}
-	filepath := "/var/vcap/data/blacksmith/"
-	filename := filepath + instanceID + ".yml"
+	filename := GetWorkDir() + instanceID + ".yml"
 	err = ioutil.WriteFile(filename, b, 0644)
 	return err
 }

--- a/manifest.go
+++ b/manifest.go
@@ -25,6 +25,8 @@ func InitManifest(p Plan, instanceID string) error {
 
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CREDENTIALS=secret/%s", instanceID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("RAWJSONFILE=/var/vcap/data/blacksmith/%s.json", instanceID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("YAMLFILE=/var/vcap/data/blacksmith/%s.yml", instanceID))
 	/* put more environment variables here, as needed */
 
 	out, err := cmd.CombinedOutput()

--- a/manifest.go
+++ b/manifest.go
@@ -27,6 +27,9 @@ func InitManifest(p Plan, instanceID string) error {
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CREDENTIALS=secret/%s", instanceID))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("RAWJSONFILE=/var/vcap/data/blacksmith/%s.json", instanceID))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("YAMLFILE=/var/vcap/data/blacksmith/%s.yml", instanceID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_WORKDIR=/var/vcap/data/blacksmith/"))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("INSTANCE_ID=%s", instanceID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_PLAN=%s", p.ID))
 	/* put more environment variables here, as needed */
 
 	out, err := cmd.CombinedOutput()

--- a/manifest.go
+++ b/manifest.go
@@ -14,12 +14,12 @@ import (
 )
 
 const (
-	// If BLACKSMITH_WORKDIR environment variable is not set, use this as a default
+	// If BLACKSMITH_INSTANCE_DATA_DIR environment variable is not set, use this as a default
 	DefaultBlacksmithWorkDir = "/var/vcap/data/blacksmith/"
 )
 
 func GetWorkDir() string {
-	var blacksmithWorkDir = os.Getenv("BLACKSMITH_WORKDIR")
+	var blacksmithWorkDir = os.Getenv("BLACKSMITH_INSTANCE_DATA_DIR")
 	if blacksmithWorkDir == "" {
 		blacksmithWorkDir = DefaultBlacksmithWorkDir
 	}
@@ -40,7 +40,7 @@ func InitManifest(p Plan, instanceID string) error {
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CREDENTIALS=secret/%s", instanceID))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("RAWJSONFILE=%s%s.json", GetWorkDir(), instanceID))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("YAMLFILE=%s%s.yml", GetWorkDir(), instanceID))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_WORKDIR=%s", GetWorkDir()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_INSTANCE_DATA_DIR=%s", GetWorkDir()))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("INSTANCE_ID=%s", instanceID))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_PLAN=%s", p.ID))
 	/* put more environment variables here, as needed */

--- a/manifest.go
+++ b/manifest.go
@@ -13,6 +13,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	// If BLACKSMITH_WORKDIR environment variable is not set, use this as a default
+	DefaultBlacksmithWorkDir = "/var/vcap/data/blacksmith/"
+)
+
+func GetWorkDir() string {
+	var blacksmithWorkDir = os.Getenv("BLACKSMITH_WORKDIR")
+	if blacksmithWorkDir == "" {
+		blacksmithWorkDir = DefaultBlacksmithWorkDir
+	}
+	return blacksmithWorkDir
+}
+
 func InitManifest(p Plan, instanceID string) error {
 	/* skip running the plan initialization script if it doesn't exist */
 	if _, err := os.Stat(p.InitScriptPath); err != nil && os.IsNotExist(err) {
@@ -25,9 +38,9 @@ func InitManifest(p Plan, instanceID string) error {
 
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CREDENTIALS=secret/%s", instanceID))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("RAWJSONFILE=/var/vcap/data/blacksmith/%s.json", instanceID))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("YAMLFILE=/var/vcap/data/blacksmith/%s.yml", instanceID))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_WORKDIR=/var/vcap/data/blacksmith/"))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("RAWJSONFILE=%s%s.json", GetWorkDir(), instanceID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("YAMLFILE=%s%s.yml", GetWorkDir(), instanceID))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_WORKDIR=%s", GetWorkDir()))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("INSTANCE_ID=%s", instanceID))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("BLACKSMITH_PLAN=%s", p.ID))
 	/* put more environment variables here, as needed */


### PR DESCRIPTION
Update blacksmith to process and include the parameters passed from the broker api.

The parameters are merged into the manifest as `meta.params:` and is also written files to allow the  `init` script to access the values to process and add to Vault if needed.  The following environmental variables are set:

```
CREDENTIALS=secret/<instanceID>
RAWJSONFILE=/var/vcap/data/blacksmith/< instanceID>.json
YAMLFILE=/var/vcap/data/blacksmith/<instanceID>.yml
BLACKSMITH_WORKDIR=/var/vcap/data/blacksmith/
INSTANCE_ID=<instanceID>
BLACKSMITH_PLAN=<ID>
```

The command `cf create-service redis standalone testdb -c '{"ram_gb":4, "something":"true"}'` will now have in the manifest like:

```
meta:
  default:
    az: z1
  net: redis-service
  params:
    ram_gb: 4
    something: true
```