### PR TITLE
Dedup unmarshal code for Vault Get. Fix task formatting bug.

### DIFF
--- a/vault_index.go
+++ b/vault_index.go
@@ -12,7 +12,8 @@ type VaultIndex struct {
 }
 
 func (v *Vault) GetIndex(path string) (*VaultIndex, error) {
-	Data, exists, err := v.Get(path)
+	Data := map[string]interface{}{}
+	exists, err := v.Get(path, &Data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The current version of Blacksmith has a bug where sufficiently large BOSH task IDs begin getting formatted in scientific notation, and therefore cannot be converted into integers to be looked up in the BOSH API. This code change deduplicates a bunch of the unmarshal code and allows for more fine-grained control over the types that the Vault JSON gets unmarshalled into (to avoid the auto-unmarshalling into float64 for numbers).

From testing in a live environment, this was found to fix the bugs with provisioning and unprovisioning. Also, I was still able to retrieve `manifest` and `task` using the BOSS CLI despite those HTTP handlers also having been changed due to the refactor.