### PR TITLE
Adding upgrade API to internal commands

### DIFF
--- a/bosh.go
+++ b/bosh.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-community/gogobosh"
+	"gopkg.in/yaml.v2"
+)
+
+func GetStemcellBlock(BOSH *gogobosh.Client, deploymentName string, useLatest bool) (map[interface{}]interface{}, error) {
+	stemcells := make(map[interface{}]interface{})
+
+	l := Logger.Wrap("Get Stemcell Block")
+
+	deployments, err := BOSH.GetDeployments()
+	if err != nil {
+		return nil, err
+	}
+	l.Info("Found deployments: %s", deployments)
+
+	stemcellYAML := ""
+	currentStemcellName := ""
+	currentStemcellVersion := ""
+
+	for _, deployment := range deployments {
+		if deployment.Name == deploymentName {
+			// We must have a stemcell listed or somethings wrong with the deployment and we should bail
+			if len(deployment.Stemcells) == 0 {
+				return nil, fmt.Errorf("Missing stemcells in %s", deployment)
+			}
+			if len(deployment.Stemcells) > 1 {
+				return nil, fmt.Errorf("too many stemcells in %s", deployment)
+			}
+
+			// Grab newest stemcell from list
+			currentStemcellName = deployment.Stemcells[len(deployment.Stemcells)-1].Name
+			currentStemcellVersion = deployment.Stemcells[len(deployment.Stemcells)-1].Version
+
+			version := ""
+			// TODO: detect stemcell type
+			if useLatest {
+				version = "latest"
+			} else {
+				version = currentStemcellVersion
+			}
+			stemcellYAML = fmt.Sprintf("---\nstemcells:\n- alias: default\n  os: ubuntu-xenial\n  version: \"%s\"\n", version)
+		}
+	}
+
+	l.Debug("Deployment %s uses Stemcell %s (%s)", deploymentName, currentStemcellName, currentStemcellVersion)
+
+	if stemcellYAML == "" {
+		return nil, fmt.Errorf("%s not found looking for stemcells", deploymentName)
+	}
+
+	err = yaml.Unmarshal([]byte(stemcellYAML), &stemcells)
+
+	return stemcells, err
+}
+
+func GetReleasesBlock(BOSH *gogobosh.Client, deploymentName string, useLatest bool) (map[interface{}]interface{}, error) {
+	releases := make(map[interface{}]interface{})
+
+	l := Logger.Wrap("Get Release Block")
+
+	deployments, err := BOSH.GetDeployments()
+	if err != nil {
+		return nil, err
+	}
+	//	l.Info("Found deployments: %s", deployments)
+
+	releaseYAML := ""
+
+	for _, deployment := range deployments {
+		if deployment.Name == deploymentName {
+			// We must have a stemcell listed or somethings wrong with the deployment and we should bail
+			if len(deployment.Releases) == 0 {
+				return nil, fmt.Errorf("Missing releases in %s", deployments)
+			}
+			releaseYAML = "---\nreleases:\n"
+
+			for _, release := range deployment.Releases {
+				l.Debug("Found release %s (%s)", release.Name, release.Version)
+
+				version := ""
+				if useLatest {
+					version = "latest"
+				} else {
+					version = release.Version
+				}
+				releaseYAML += fmt.Sprintf("- name: \"%s\"\n  version: \"%s\"\n", release.Name, version)
+			}
+		}
+	}
+
+	l.Debug("Releases Block %s", releaseYAML)
+
+	if releaseYAML == "" {
+		return nil, fmt.Errorf("%s not found looking for releases", deploymentName)
+	}
+
+	err = yaml.Unmarshal([]byte(releaseYAML), &releases)
+
+	return releases, err
+}

--- a/internal_api.go
+++ b/internal_api.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/geofffranks/simpleyaml"
+	"github.com/geofffranks/spruce"
 	"gopkg.in/yaml.v2"
 )
 
@@ -95,7 +97,7 @@ func (api *InternalApi) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	pattern = regexp.MustCompile("^/b/([^/]+)/redeploy$")
 	if m := pattern.FindStringSubmatch(req.URL.Path); m != nil {
-		l := Logger.Wrap("update-service")
+		l := Logger.Wrap("redeploy-service")
 		l.Debug("looking up BOSH manifest for %s", m[1])
 		manifest := struct {
 			Manifest string `json:"manifest"`
@@ -114,6 +116,162 @@ func (api *InternalApi) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, "{\"message\": \"Redeploy of %s requested in task %d\"}", m[1], task.ID)
+		return
+	}
+
+	pattern = regexp.MustCompile("^/b/([^/]+)/upgrade")
+	if m := pattern.FindStringSubmatch(req.URL.Path); m != nil {
+		instanceID := m[1]
+		l := Logger.Wrap("update-service")
+
+		l.Debug("looking up credentials for %s", m[1])
+		inst, exists, err := api.Vault.FindInstance(m[1])
+		if err != nil || !exists {
+			l.Error("unable to find service instance %s in vault index", m[1])
+		}
+		l.Debug("looking up service '%s' / plan '%s' in catalog", inst.ServiceID, inst.PlanID)
+		plan, err := api.Broker.FindPlan(inst.ServiceID, inst.PlanID)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "---\nerror: unable to find plan '%s'\n\n", inst.PlanID)
+			return
+		}
+
+		// Default options for upgrades
+		upgradeStemcells := true
+		upgradeReleases := false
+
+		l.Debug("looking up BOSH manifest for %s in Vault", instanceID)
+		vault_manifest := struct {
+			Manifest string `json:"manifest"`
+		}{}
+
+		exists, err = api.Vault.Get(fmt.Sprintf("%s/manifest", instanceID), &vault_manifest)
+		if err != nil || !exists {
+			l.Error("unable to find service instance %s in vault index", instanceID)
+			w.WriteHeader(404)
+			return
+		}
+		if vault_manifest.Manifest == "" {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Deployment '%s' empty\n", instanceID)
+			return
+		}
+
+		y, err := simpleyaml.NewYaml([]byte(vault_manifest.Manifest))
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "YAML '%s' invalid\n", vault_manifest.Manifest)
+			return
+		}
+
+		deploymentName, err := y.Get("name").String()
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Deployment name missing\n")
+			return
+		}
+
+		// Get current Manifest from BOSH
+		l.Debug("Determined BOSH deployment name to be %s", deploymentName)
+		l.Debug("Looking up live manifest for %s from BOSH", instanceID)
+
+		boshManifest := struct {
+			Manifest string `json:"manifest"`
+		}{}
+
+		boshManifest, err = api.Broker.BOSH.GetDeployment(deploymentName)
+		if err != nil || boshManifest.Manifest == "" {
+			w.WriteHeader(404)
+			fmt.Fprintf(w, "Deployment '%s' not found.  Err: %s\n", deploymentName, err)
+			return
+		}
+
+		canUpgradeRelease, err := UpgradePrep(plan, instanceID, boshManifest.Manifest)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Err getting Deployments: %s\n", err)
+			return
+		}
+		l.Info("Can Upgrade Debug check returned %s", canUpgradeRelease)
+
+		stemcellVersion, err := GetStemcellBlock(api.Broker.BOSH, deploymentName, upgradeStemcells)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Error getting stemcell versions: %s\n", err)
+			return
+		}
+
+		allReleaseVersions, err := GetReleasesBlock(api.Broker.BOSH, deploymentName, upgradeReleases)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Error getting previous releases: %s\n", err)
+			return
+		}
+
+		mappedManifest := make(map[interface{}]interface{})
+		err = yaml.Unmarshal([]byte(boshManifest.Manifest), &mappedManifest)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Error parsing bosh manifest: %s\n", err)
+			return
+		}
+
+		spruceManifest, err := spruce.Merge(mappedManifest, allReleaseVersions, stemcellVersion)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "Error locking release versions: %s\n", err)
+			return
+		}
+
+		spruceYamlManifest, _ := yaml.Marshal(spruceManifest)
+		targetManifest := string(spruceYamlManifest)
+
+		if canUpgradeRelease == true {
+			l.Debug("Generating manifest for updating service deployment")
+			params := make(map[interface{}]interface{})
+
+			// TODO: Load params from Vault
+			defaults := make(map[interface{}]interface{})
+			defaults["name"] = deploymentName
+
+			// Release versions and Stemcell versions will be set by GenManifest
+			new_manifest, err := GenManifest(plan, defaults, wrap("meta.params", params), stemcellVersion)
+			if err != nil {
+				w.WriteHeader(500)
+				fmt.Fprintf(w, "failed to generate service deployment manifest: %s", err)
+				return
+			}
+			targetManifest = new_manifest
+		} else {
+			l.Debug("Cannot upgrade Release, using original manifest")
+		}
+
+		///===============================================
+		err = api.Vault.Put(fmt.Sprintf("%s/manifest", instanceID), map[string]interface{}{
+			"manifest": targetManifest,
+		})
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "failed to store generated manifest in the vault (aborting): %s", err)
+			return
+		}
+
+		l.Debug("uploading releases (if necessary) to BOSH director")
+		err = UploadReleasesFromManifest(targetManifest, api.Broker.BOSH, l)
+		if err != nil {
+			l.Error("failed to upload service deployment releases: %s", err)
+
+		}
+
+		task, err := api.Broker.BOSH.CreateDeployment(targetManifest)
+		if err != nil {
+			w.WriteHeader(500)
+			fmt.Fprintf(w, "error trying to deploy upgrade to %s: %s\n", instanceID, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, "{\"message\": \"Upgrade of %s requested in task %d\"}", instanceID, task.ID)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ func main() {
 		log.Fatal(err)
 	}
 
+	_ = vault.EnsureVaultV2()
+
 	bosh, err := gogobosh.NewClient(&gogobosh.Config{
 		BOSHAddress:       config.BOSH.Address,
 		Username:          config.BOSH.Username,

--- a/services.go
+++ b/services.go
@@ -15,9 +15,10 @@ type Plan struct {
 	Description string `yaml:"description" json:"description"`
 	Limit       int    `yaml:"limit" json:"limit"`
 
-	Manifest       map[interface{}]interface{} `json:"-"`
-	Credentials    map[interface{}]interface{} `json:"-"`
-	InitScriptPath string                      `json:"-"`
+	Manifest          map[interface{}]interface{} `json:"-"`
+	Credentials       map[interface{}]interface{} `json:"-"`
+	InitScriptPath    string                      `json:"-"`
+	UpgradeScriptPath string                      `json:"-"`
 
 	Service *Service `yaml:"service" json:"service"`
 }

--- a/services.go
+++ b/services.go
@@ -129,6 +129,7 @@ func ReadPlan(path string) (p Plan, err error) {
 	}
 
 	p.InitScriptPath = fmt.Sprintf("%s/init", path)
+	p.UpgradeScriptPath = fmt.Sprintf("%s/upgrade", path)
 	return
 }
 


### PR DESCRIPTION
Adding Upgrade API command that will upgrade the stemcell and will check if it's safe to also upgrade the releases.  

Forges that wish to have in place service upgrades can provide an "Upgrade" script to the forge that can perform any credential updates needed before regenerating the manifest with the newer release.  If the script returns success, the manifest is regenerated and deployed, if it's unavailable or fails, only the stemcells will be bumped.

TODO: Allow users to pass in options such as "Stemcell only" 

