### PR TITLE
remove admin user/pass rmq

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -402,6 +402,24 @@ func (b *Broker) Bind(instanceID, bindingID string, details brokerapi.BindDetail
 		return binding, err
 	}
 
+	if m, ok := creds.(map[string]interface{}); ok {
+		if ok {
+			elem, ok := m["admin_username"]
+			if elem, ok = m["admin_username"]; ok {
+				if ok {
+					delete(m, "admin_username")
+				}
+			}
+			if elem, ok = m["admin_password"]; ok {
+				if ok {
+					delete(m, "admin_password")
+				}
+			}
+			_ = elem
+			creds = m
+		}
+	}
+
 	binding.Credentials = creds
 	l.Debug("credentials are: %v", binding)
 

--- a/broker.go
+++ b/broker.go
@@ -403,21 +403,8 @@ func (b *Broker) Bind(instanceID, bindingID string, details brokerapi.BindDetail
 	}
 
 	if m, ok := creds.(map[string]interface{}); ok {
-		if ok {
-			elem, ok := m["admin_username"]
-			if elem, ok = m["admin_username"]; ok {
-				if ok {
-					delete(m, "admin_username")
-				}
-			}
-			if elem, ok = m["admin_password"]; ok {
-				if ok {
-					delete(m, "admin_password")
-				}
-			}
-			_ = elem
-			creds = m
-		}
+		delete(m, "admin_username")
+		delete(m, "admin_password")
 	}
 
 	binding.Credentials = creds


### PR DESCRIPTION
Checks for the presence of an `admin_username` or `admin_password` on creds and removes it.