### PR TITLE
RabbitMQ Dynamic credentials

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -661,6 +661,5 @@ func (b *Broker) serviceWithNoDeploymentCheck() ([]string, error) {
 			}
 		}
 	}
-	l.Debug("current value of removedDeploymentNames: %v", removedDeploymentNames)
 	return removedDeploymentNames, nil
 }

--- a/broker.go
+++ b/broker.go
@@ -431,10 +431,6 @@ func (b *Broker) Bind(instanceID, bindingID string, details brokerapi.BindDetail
 				return binding, err
 			}
 
-			m["username"] = usernameDynamic
-			m["password"] = passwordDynamic
-			m["credential_type"] = "dynamic"
-
 			creds, err = yamlGsub(creds, usernameStatic, usernameDynamic)
 			if err != nil {
 				return binding, err

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/drewolson/testflight v1.0.0 // indirect
 	github.com/geofffranks/spruce v1.27.0
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab // indirect
+	github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f
 	github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11 // indirect
 	github.com/onsi/ginkgo v1.13.0
 	github.com/onsi/gomega v1.10.1

--- a/main.go
+++ b/main.go
@@ -227,7 +227,7 @@ func main() {
 		l.Info("shutting down blacksmith service broker")
 	}()
 
-	BoshMaintenanceLoop := time.NewTicker(1 * time.Hour)
+	BoshMaintenanceLoop := time.NewTicker(1 * time.Minute)
 	//TODO set task to -1 or something out here and check to make sure the cleanup is finished before you run another one
 	for {
 		select {
@@ -238,11 +238,12 @@ func main() {
 			}
 			l.Info("current vault db looks like: %v", vaultDB.Data)
 			broker.serviceWithNoDeploymentCheck()
-			task, err := bosh.Cleanup(false)
-			l.Info("taskid for the bosh cleanup is %v", task.ID)
-			if err != nil {
-				l.Error("bosh cleanup failed to run properly: %s", err)
-			}
+//			Disable cleanup process, using external bosh director
+//			task, err := bosh.Cleanup(false)
+//			l.Info("taskid for the bosh cleanup is %v", task.ID)
+//			if err != nil {
+//				l.Error("bosh cleanup failed to run properly: %s", err)
+//			}
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -227,7 +227,7 @@ func main() {
 		l.Info("shutting down blacksmith service broker")
 	}()
 
-	BoshMaintenanceLoop := time.NewTicker(1 * time.Minute)
+	BoshMaintenanceLoop := time.NewTicker(1 * time.Hour)
 	//TODO set task to -1 or something out here and check to make sure the cleanup is finished before you run another one
 	for {
 		select {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,6 +66,7 @@ github.com/geofffranks/yaml
 # github.com/golang/protobuf v1.4.2
 github.com/golang/protobuf/proto
 # github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f
+## explicit
 github.com/google/uuid
 # github.com/gorilla/mux v1.7.3
 github.com/gorilla/mux


### PR DESCRIPTION
# Features

* Rabbitmq Dynamic Credentials

Updates the binding process so that if `api_url` exists on the credentials tied to the service broker:

* collects `admin_username`, `admin_password` and `vhost`
* sets `usernameDynamic` to the `bindingID` and `passwordDynamic` to a random uuid
* stores already present `username` and `password` under `usernameStatic` and `passwordStatic`
* adds and uses `CreateUserPassRabbitMQ` function which creates the the user using RabbitMQ's api
* adds and uses `GrantUserPermissionsRabbitMQ` function which applies the permissions
* adds and uses `yamlGsub` function to replace already present `usernameStatic` and `passwordStatic` strings with the new `usernameDynamic` and `passwordDynamic`
* updates `username`, `password` and set `credential_type` to `dynamic`

Updates the unbinding process so that if `rabbitmq` is found within `PlanID`:

* caches the plan details
* caches the credentials for that plan
* collects `admin_username`, `admin_password` and `apiUrl`
* adds and uses `DeletetUserRabbitMQ` to delete the user/bindingID using RabbitMQ's api

# Bugs

* Disable failing bosh cleanup - relying on external bosh director