### PR TITLE
Update FQDN and provide params.hostname

### DIFF
--- a/services.go
+++ b/services.go
@@ -14,6 +14,7 @@ type Plan struct {
 	Name        string `yaml:"name" json:"name"`
 	Description string `yaml:"description" json:"description"`
 	Limit       int    `yaml:"limit" json:"limit"`
+	Type        string `yaml:"type" json:"type"`
 
 	Manifest       map[interface{}]interface{} `json:"-"`
 	Credentials    map[interface{}]interface{} `json:"-"`
@@ -25,6 +26,7 @@ type Plan struct {
 type Service struct {
 	ID          string   `yaml:"id" json:"id"`
 	Name        string   `yaml:"name" json:"name"`
+	Type        string   `yaml:"type" json:"type"`
 	Description string   `yaml:"description" json:"description"`
 	Bindable    bool     `yaml:"bindable" json:"bindable"`
 	Tags        []string `yaml:"tags" json:"tags"`
@@ -150,6 +152,7 @@ func ReadPlans(dir string, service Service) ([]Plan, error) {
 				return pp, err
 			}
 			p.ID = service.ID + "-" + p.ID
+			p.Type = service.Type
 			p.Service = &service
 			pp = append(pp, p)
 		}


### PR DESCRIPTION
*  provide the DNS record required for communicating to service instances deployed by blacksmith.

Blacksmith has a [Job](https://github.com/blacksmith-community/blacksmith/blob/v0.11.1/broker.go#L29-L38) struct which is being populated with values from the GetCreds function [here](https://github.com/blacksmith-community/blacksmith/blob/v0.11.1/manifest.go#L155-L166). The job.FQDN was constructed from 
```
vm.ID + "." + plan.ID + "." + network + "." + deployment + ".bosh"
```
This resulted in a value different than the routable dns record pushed to the instances. Specifically:

dc0f65a0-3703-4dc6-be6d-7e6d09a8aa63.rabbitmq-single-node.blacksmith.rabbitmq-single-node-f089e366-4494-4d36-a8de-6f2b099eca50.bosh
vs

dc0f65a0-3703-4dc6-be6d-7e6d09a8aa63.standalone.blacksmith.rabbitmq-single-node-f089e366-4494-4d36-a8de-6f2b099eca50.bosh
(note rabbitmq-single-node vs standalone)

To address this the following changes were introduced:

plan.ID was changed to plan.Type

The Plan struct was added the corresponding Type along with the Service struct and ReadPlans function was updated to populate p.Type (plan.Type) from the service.Type . Finally the spec was updated to include a description and a default value to standalone. 

Migrating this process to a cluster deployment type of RabbitMQ surfaced the fact that the service.Type is a [default](https://github.com/genesis-community/blacksmith-genesis-kit/blob/develop/manifests/forges/rabbitmq.yml#L40) value offered to RabbitMQ deployment as a whole and does not differentiate between plans.

To address this a logic was added to manifest.go so that when job.PlanName is not `single-node` in replaces the value to `node`.

A variable was added named dnsname and was later then populated with the updated job.FQDN. Finally, a params["hostname"] was added populated by dnsname.