### PR TITLE
expand plan name matching

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -161,7 +161,7 @@ func GetCreds(id string, plan Plan, bosh *gogobosh.Client, l *Log) (interface{},
 		}
 		l.Debug("found job {name: %s, deployment: %s, id: %s, plan_id: %s, plan_name: %s, fqdn: %s, ips: [%s], dns: [%s]", job.Name, job.Deployment, job.ID, job.PlanID, job.PlanName, job.FQDN, strings.Join(vm.IPs, ", "), strings.Join(vm.DNS, ", "))
 		dnsname = job.FQDN
-		if job.PlanName != "single-node" {
+		if !strings.Contains(job.PlanName, "single-node") {
 			dnsname = strings.Replace(dnsname, ".standalone.", ".node.", 1)
 		}
 


### PR DESCRIPTION
expands the replacement to a plan containing the string `single-node`