### PR TITLE
Feature/per binding acl

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -546,6 +546,12 @@ func (b *Broker) Bind(
 		return binding, err
 	}
 
+	// Process Valkey dynamic credentials if applicable
+	processedCreds, err = b.processValkeyCredentials(ctx, bindingID, processedCreds, logger)
+	if err != nil {
+		return binding, err
+	}
+
 	// Clean up admin credentials from final output
 	b.cleanupAdminCredentials(processedCreds)
 
@@ -574,6 +580,13 @@ func (b *Broker) Unbind(
 
 	if strings.Contains(details.PlanID, "rabbitmq") {
 		err := b.handleRabbitMQUnbind(ctx, instanceID, bindingID, details, logger)
+		if err != nil {
+			return domain.UnbindSpec{}, err
+		}
+	}
+
+	if strings.Contains(details.PlanID, "valkey") {
+		err := b.handleValkeyUnbind(ctx, instanceID, bindingID, details, logger)
 		if err != nil {
 			return domain.UnbindSpec{}, err
 		}
@@ -1138,6 +1151,21 @@ func (b *Broker) processDynamicCredentials(ctx context.Context, credsMap map[str
 		binding.CredentialType = "dynamic"
 
 		logger.Debug("Successfully processed dynamic RabbitMQ credentials")
+	}
+
+	if serviceType, ok := credsMap["service_type"].(string); ok && serviceType == "valkey" {
+		logger.Info("Processing Valkey ACL user for binding", "bindingID", bindingID)
+
+		err := b.handleDynamicValkeyCredentials(ctx, credsMap, bindingID, logger)
+		if err != nil {
+			logger.Error("Failed to handle dynamic Valkey credentials", "error", err)
+
+			return fmt.Errorf("failed to handle dynamic Valkey credentials: %w", err)
+		}
+
+		binding.CredentialType = "dynamic"
+
+		logger.Debug("Successfully processed dynamic Valkey credentials")
 	}
 
 	return nil
@@ -2269,6 +2297,7 @@ func (b *Broker) cleanupAdminCredentials(creds interface{}) {
 	if credMap, ok := creds.(map[string]interface{}); ok {
 		delete(credMap, "admin_username")
 		delete(credMap, "admin_password")
+		delete(credMap, "service_type")
 	}
 }
 
@@ -2653,7 +2682,7 @@ func (b *Broker) populateBindingCredentials(binding *BindingCredentials, credsMa
 func filterAdminCredentials(credsMap map[string]interface{}) map[string]interface{} {
 	filtered := make(map[string]interface{}, len(credsMap))
 	for k, v := range credsMap {
-		if k != "admin_username" && k != "admin_password" {
+		if k != "admin_username" && k != "admin_password" && k != "service_type" {
 			filtered[k] = v
 		}
 	}

--- a/internal/broker/valkey.go
+++ b/internal/broker/valkey.go
@@ -33,6 +33,16 @@ const (
 	valkeyOpTimeout   = 10 * time.Second
 )
 
+// valkeyConnInfo holds the connection details extracted from a credential map.
+type valkeyConnInfo struct {
+	adminPassword string
+	host          string
+	port          int
+	tlsPort       int
+	useTLS        bool
+	hosts         []string // non-nil for cluster
+}
+
 // IsValkeyService returns true if the credential map indicates a Valkey service.
 // Exported for testing.
 func IsValkeyService(credMap map[string]interface{}) bool {
@@ -40,21 +50,8 @@ func IsValkeyService(credMap map[string]interface{}) bool {
 	return ok && serviceType == "valkey"
 }
 
-// processValkeyCredentials creates a per-binding ACL user on the Valkey
-// instance and replaces the shared credentials with binding-specific ones.
-// For non-Valkey services the credentials are returned unchanged.
-func (b *Broker) processValkeyCredentials(ctx context.Context, bindingID string, creds interface{}, logger logger.Logger) (interface{}, error) {
-	credMap, ok := creds.(map[string]interface{})
-	if !ok {
-		return creds, nil
-	}
-
-	if !IsValkeyService(credMap) {
-		return creds, nil
-	}
-
-	logger.Info("Processing Valkey ACL credentials for binding %s", bindingID)
-
+// extractValkeyConnInfo extracts connection details from a credential map.
+func extractValkeyConnInfo(credMap map[string]interface{}) (*valkeyConnInfo, error) {
 	adminPassword, ok := credMap["admin_password"].(string)
 	if !ok || adminPassword == "" {
 		return nil, ErrValkeyAdminPasswordMissing
@@ -65,40 +62,76 @@ func (b *Broker) processValkeyCredentials(ctx context.Context, bindingID string,
 		return nil, ErrValkeyHostMissing
 	}
 
-	port := 6379
-	if p, ok := credMap["port"].(int); ok && p > 0 {
-		port = p
-	} else if p, ok := credMap["port"].(float64); ok && p > 0 {
-		port = int(p)
+	port := extractIntField(credMap, "port", 6379)
+	tlsPort := extractIntField(credMap, "tls_port", 0)
+
+	return &valkeyConnInfo{
+		adminPassword: adminPassword,
+		host:          host,
+		port:          port,
+		tlsPort:       tlsPort,
+		useTLS:        tlsPort > 0,
+		hosts:         ExtractHosts(credMap),
+	}, nil
+}
+
+// extractIntField reads an int from the credential map, handling both int and
+// float64 types (YAML/JSON unmarshaling may produce either).
+func extractIntField(credMap map[string]interface{}, key string, defaultVal int) int {
+	if p, ok := credMap[key].(int); ok && p > 0 {
+		return p
 	}
 
-	tlsPort := 0
-	if p, ok := credMap["tls_port"].(int); ok {
-		tlsPort = p
-	} else if p, ok := credMap["tls_port"].(float64); ok {
-		tlsPort = int(p)
+	if p, ok := credMap[key].(float64); ok && p > 0 {
+		return int(p)
 	}
 
-	useTLS := tlsPort > 0
+	return defaultVal
+}
+
+// createACLUser dispatches to standalone or cluster variant based on
+// whether hosts are present in the connection info.
+func (b *Broker) createACLUser(ctx context.Context, conn *valkeyConnInfo, username, password string, logger logger.Logger) error {
+	if len(conn.hosts) > 0 {
+		return b.createValkeyACLUserOnAllNodes(ctx, conn.hosts, conn.port, conn.adminPassword, username, password, conn.useTLS, conn.tlsPort, logger)
+	}
+
+	return b.createValkeyACLUser(ctx, conn.host, conn.port, conn.adminPassword, username, password, conn.useTLS, conn.tlsPort, logger)
+}
+
+// deleteACLUser dispatches to standalone or cluster variant based on
+// whether hosts are present in the connection info.
+func (b *Broker) deleteACLUser(ctx context.Context, conn *valkeyConnInfo, username string, logger logger.Logger) error {
+	if len(conn.hosts) > 0 {
+		return b.deleteValkeyACLUserOnAllNodes(ctx, conn.hosts, conn.port, conn.adminPassword, username, conn.useTLS, conn.tlsPort, logger)
+	}
+
+	return b.deleteValkeyACLUser(ctx, conn.host, conn.port, conn.adminPassword, username, conn.useTLS, conn.tlsPort, logger)
+}
+
+// processValkeyCredentials creates a per-binding ACL user on the Valkey
+// instance and replaces the shared credentials with binding-specific ones.
+// For non-Valkey services the credentials are returned unchanged.
+func (b *Broker) processValkeyCredentials(ctx context.Context, bindingID string, creds interface{}, logger logger.Logger) (interface{}, error) {
+	credMap, ok := creds.(map[string]interface{})
+	if !ok || !IsValkeyService(credMap) {
+		return creds, nil
+	}
+
+	logger.Info("Processing Valkey ACL credentials for binding %s", bindingID)
+
+	conn, err := extractValkeyConnInfo(credMap)
+	if err != nil {
+		return nil, err
+	}
 
 	dynamicUsername := bindingID
 	dynamicPassword := uuid.New().String()
 
-	// Determine standalone vs cluster
-	hosts := ExtractHosts(credMap)
-	if len(hosts) > 0 {
-		err := b.createValkeyACLUserOnAllNodes(ctx, hosts, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err := b.createValkeyACLUser(ctx, host, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger)
-		if err != nil {
-			return nil, err
-		}
+	if err := b.createACLUser(ctx, conn, dynamicUsername, dynamicPassword, logger); err != nil {
+		return nil, err
 	}
 
-	// Replace credentials with per-binding values
 	credMap["username"] = dynamicUsername
 	credMap["password"] = dynamicPassword
 	credMap["credential_type"] = credentialTypeDynamic
@@ -109,44 +142,16 @@ func (b *Broker) processValkeyCredentials(ctx context.Context, bindingID string,
 // handleDynamicValkeyCredentials is the GetBindingCredentials-path handler,
 // mirroring handleDynamicRabbitMQCredentials.
 func (b *Broker) handleDynamicValkeyCredentials(ctx context.Context, credsMap map[string]interface{}, bindingID string, logger logger.Logger) error {
-	adminPassword, ok := credsMap["admin_password"].(string)
-	if !ok || adminPassword == "" {
-		return ErrValkeyAdminPasswordMissing
+	conn, err := extractValkeyConnInfo(credsMap)
+	if err != nil {
+		return err
 	}
-
-	host, ok := credsMap["host"].(string)
-	if !ok || host == "" {
-		return ErrValkeyHostMissing
-	}
-
-	port := 6379
-	if p, ok := credsMap["port"].(int); ok && p > 0 {
-		port = p
-	} else if p, ok := credsMap["port"].(float64); ok && p > 0 {
-		port = int(p)
-	}
-
-	tlsPort := 0
-	if p, ok := credsMap["tls_port"].(int); ok {
-		tlsPort = p
-	} else if p, ok := credsMap["tls_port"].(float64); ok {
-		tlsPort = int(p)
-	}
-
-	useTLS := tlsPort > 0
 
 	dynamicUsername := bindingID
 	dynamicPassword := uuid.New().String()
 
-	hosts := ExtractHosts(credsMap)
-	if len(hosts) > 0 {
-		if err := b.createValkeyACLUserOnAllNodes(ctx, hosts, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger); err != nil {
-			return err
-		}
-	} else {
-		if err := b.createValkeyACLUser(ctx, host, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger); err != nil {
-			return err
-		}
+	if err := b.createACLUser(ctx, conn, dynamicUsername, dynamicPassword, logger); err != nil {
+		return err
 	}
 
 	credsMap["username"] = dynamicUsername
@@ -174,38 +179,12 @@ func (b *Broker) handleValkeyUnbind(ctx context.Context, instanceID, bindingID s
 		return err
 	}
 
-	adminPassword, ok := credMap["admin_password"].(string)
-	if !ok || adminPassword == "" {
-		return ErrValkeyAdminPasswordMissing
+	conn, err := extractValkeyConnInfo(credMap)
+	if err != nil {
+		return err
 	}
 
-	host, ok := credMap["host"].(string)
-	if !ok || host == "" {
-		return ErrValkeyHostMissing
-	}
-
-	port := 6379
-	if p, ok := credMap["port"].(int); ok && p > 0 {
-		port = p
-	} else if p, ok := credMap["port"].(float64); ok && p > 0 {
-		port = int(p)
-	}
-
-	tlsPort := 0
-	if p, ok := credMap["tls_port"].(int); ok {
-		tlsPort = p
-	} else if p, ok := credMap["tls_port"].(float64); ok {
-		tlsPort = int(p)
-	}
-
-	useTLS := tlsPort > 0
-
-	hosts := ExtractHosts(credMap)
-	if len(hosts) > 0 {
-		return b.deleteValkeyACLUserOnAllNodes(ctx, hosts, port, adminPassword, bindingID, useTLS, tlsPort, logger)
-	}
-
-	return b.deleteValkeyACLUser(ctx, host, port, adminPassword, bindingID, useTLS, tlsPort, logger)
+	return b.deleteACLUser(ctx, conn, bindingID, logger)
 }
 
 // getValkeyCredentials retrieves the raw credential map for a Valkey instance.
@@ -240,18 +219,14 @@ func (b *Broker) createValkeyACLUser(ctx context.Context, host string, port int,
 		}
 		defer client.Close()
 
-		// ACL SETUSER <username> on ><password> ~* &* +@all -@admin
 		result := client.Do(ctx, "ACL", "SETUSER", username, "on", ">"+password, "~*", "&*", "+@all", "-@admin")
 		if result.Err() != nil {
 			logger.Error("ACL SETUSER failed: %s", result.Err())
 			return fmt.Errorf("%w: SETUSER: %w", ErrValkeyACLCommandFailed, result.Err())
 		}
 
-		// ACL SAVE to persist
-		saveResult := client.Do(ctx, "ACL", "SAVE")
-		if saveResult.Err() != nil {
-			logger.Error("ACL SAVE failed: %s", saveResult.Err())
-			return fmt.Errorf("%w: SAVE: %w", ErrValkeyACLCommandFailed, saveResult.Err())
+		if err := aclSave(ctx, client, logger); err != nil {
+			return err
 		}
 
 		logger.Debug("Successfully created ACL user %s", username)
@@ -280,6 +255,8 @@ func (b *Broker) createValkeyACLUserOnAllNodes(ctx context.Context, hosts []stri
 }
 
 // deleteValkeyACLUser deletes an ACL user from one Valkey node.
+// ACL DELUSER is naturally idempotent — it returns 0 for non-existent users
+// without raising an error.
 func (b *Broker) deleteValkeyACLUser(ctx context.Context, host string, port int, adminPassword, username string, useTLS bool, tlsPort int, logger logger.Logger) error {
 	logger.Info("Deleting Valkey ACL user %s on %s:%d", username, host, port)
 
@@ -292,21 +269,12 @@ func (b *Broker) deleteValkeyACLUser(ctx context.Context, host string, port int,
 
 		result := client.Do(ctx, "ACL", "DELUSER", username)
 		if result.Err() != nil {
-			// User not found is success (idempotent)
-			if strings.Contains(result.Err().Error(), "ERR The user") {
-				logger.Info("ACL user %s does not exist, treating as success", username)
-				return nil
-			}
-
 			logger.Error("ACL DELUSER failed: %s", result.Err())
-
 			return fmt.Errorf("%w: DELUSER: %w", ErrValkeyACLCommandFailed, result.Err())
 		}
 
-		saveResult := client.Do(ctx, "ACL", "SAVE")
-		if saveResult.Err() != nil {
-			logger.Error("ACL SAVE failed: %s", saveResult.Err())
-			return fmt.Errorf("%w: SAVE: %w", ErrValkeyACLCommandFailed, saveResult.Err())
+		if err := aclSave(ctx, client, logger); err != nil {
+			return err
 		}
 
 		logger.Debug("Successfully deleted ACL user %s", username)
@@ -329,6 +297,17 @@ func (b *Broker) deleteValkeyACLUserOnAllNodes(ctx context.Context, hosts []stri
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %s", ErrFailedToDeleteValkeyACLUser, strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// aclSave persists the current ACL state to the aclfile.
+func aclSave(ctx context.Context, client *redis.Client, logger logger.Logger) error {
+	result := client.Do(ctx, "ACL", "SAVE")
+	if result.Err() != nil {
+		logger.Error("ACL SAVE failed: %s", result.Err())
+		return fmt.Errorf("%w: SAVE: %w", ErrValkeyACLCommandFailed, result.Err())
 	}
 
 	return nil
@@ -364,7 +343,7 @@ func connectToValkeyAdmin(ctx context.Context, host string, port int, adminPassw
 
 	if err := client.Ping(pingCtx).Err(); err != nil {
 		client.Close()
-		return nil, fmt.Errorf("Valkey ping failed at %s: %w", opts.Addr, err)
+		return nil, fmt.Errorf("valkey ping failed at %s: %w", opts.Addr, err)
 	}
 
 	return client, nil

--- a/internal/broker/valkey.go
+++ b/internal/broker/valkey.go
@@ -23,7 +23,7 @@ var (
 	ErrFailedToDeleteValkeyACLUser = errors.New("failed to delete Valkey ACL user")
 	ErrValkeyAdminPasswordMissing  = errors.New("admin_password required for Valkey service")
 	ErrValkeyHostMissing           = errors.New("host required for Valkey service")
-	ErrValkeyACLCommandFailed      = errors.New("Valkey ACL command failed")
+	ErrValkeyACLCommandFailed      = errors.New("valkey ACL command failed")
 )
 
 const (

--- a/internal/broker/valkey.go
+++ b/internal/broker/valkey.go
@@ -1,0 +1,401 @@
+package broker
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"blacksmith/internal/manifest"
+	"blacksmith/internal/services"
+	"blacksmith/pkg/logger"
+	"blacksmith/pkg/services/common"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var (
+	ErrFailedToCreateValkeyACLUser = errors.New("failed to create Valkey ACL user")
+	ErrFailedToDeleteValkeyACLUser = errors.New("failed to delete Valkey ACL user")
+	ErrValkeyAdminPasswordMissing  = errors.New("admin_password required for Valkey service")
+	ErrValkeyHostMissing           = errors.New("host required for Valkey service")
+	ErrValkeyACLCommandFailed      = errors.New("Valkey ACL command failed")
+)
+
+const (
+	valkeyACLRetries  = 3
+	valkeyACLBaseWait = 1 * time.Second
+	valkeyDialTimeout = 5 * time.Second
+	valkeyOpTimeout   = 10 * time.Second
+)
+
+// IsValkeyService returns true if the credential map indicates a Valkey service.
+// Exported for testing.
+func IsValkeyService(credMap map[string]interface{}) bool {
+	serviceType, ok := credMap["service_type"].(string)
+	return ok && serviceType == "valkey"
+}
+
+// processValkeyCredentials creates a per-binding ACL user on the Valkey
+// instance and replaces the shared credentials with binding-specific ones.
+// For non-Valkey services the credentials are returned unchanged.
+func (b *Broker) processValkeyCredentials(ctx context.Context, bindingID string, creds interface{}, logger logger.Logger) (interface{}, error) {
+	credMap, ok := creds.(map[string]interface{})
+	if !ok {
+		return creds, nil
+	}
+
+	if !IsValkeyService(credMap) {
+		return creds, nil
+	}
+
+	logger.Info("Processing Valkey ACL credentials for binding %s", bindingID)
+
+	adminPassword, ok := credMap["admin_password"].(string)
+	if !ok || adminPassword == "" {
+		return nil, ErrValkeyAdminPasswordMissing
+	}
+
+	host, ok := credMap["host"].(string)
+	if !ok || host == "" {
+		return nil, ErrValkeyHostMissing
+	}
+
+	port := 6379
+	if p, ok := credMap["port"].(int); ok && p > 0 {
+		port = p
+	} else if p, ok := credMap["port"].(float64); ok && p > 0 {
+		port = int(p)
+	}
+
+	tlsPort := 0
+	if p, ok := credMap["tls_port"].(int); ok {
+		tlsPort = p
+	} else if p, ok := credMap["tls_port"].(float64); ok {
+		tlsPort = int(p)
+	}
+
+	useTLS := tlsPort > 0
+
+	dynamicUsername := bindingID
+	dynamicPassword := uuid.New().String()
+
+	// Determine standalone vs cluster
+	hosts := ExtractHosts(credMap)
+	if len(hosts) > 0 {
+		err := b.createValkeyACLUserOnAllNodes(ctx, hosts, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := b.createValkeyACLUser(ctx, host, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Replace credentials with per-binding values
+	credMap["username"] = dynamicUsername
+	credMap["password"] = dynamicPassword
+	credMap["credential_type"] = credentialTypeDynamic
+
+	return creds, nil
+}
+
+// handleDynamicValkeyCredentials is the GetBindingCredentials-path handler,
+// mirroring handleDynamicRabbitMQCredentials.
+func (b *Broker) handleDynamicValkeyCredentials(ctx context.Context, credsMap map[string]interface{}, bindingID string, logger logger.Logger) error {
+	adminPassword, ok := credsMap["admin_password"].(string)
+	if !ok || adminPassword == "" {
+		return ErrValkeyAdminPasswordMissing
+	}
+
+	host, ok := credsMap["host"].(string)
+	if !ok || host == "" {
+		return ErrValkeyHostMissing
+	}
+
+	port := 6379
+	if p, ok := credsMap["port"].(int); ok && p > 0 {
+		port = p
+	} else if p, ok := credsMap["port"].(float64); ok && p > 0 {
+		port = int(p)
+	}
+
+	tlsPort := 0
+	if p, ok := credsMap["tls_port"].(int); ok {
+		tlsPort = p
+	} else if p, ok := credsMap["tls_port"].(float64); ok {
+		tlsPort = int(p)
+	}
+
+	useTLS := tlsPort > 0
+
+	dynamicUsername := bindingID
+	dynamicPassword := uuid.New().String()
+
+	hosts := ExtractHosts(credsMap)
+	if len(hosts) > 0 {
+		if err := b.createValkeyACLUserOnAllNodes(ctx, hosts, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger); err != nil {
+			return err
+		}
+	} else {
+		if err := b.createValkeyACLUser(ctx, host, port, adminPassword, dynamicUsername, dynamicPassword, useTLS, tlsPort, logger); err != nil {
+			return err
+		}
+	}
+
+	credsMap["username"] = dynamicUsername
+	credsMap["password"] = dynamicPassword
+	credsMap["credential_type"] = credentialTypeDynamic
+
+	delete(credsMap, "admin_password")
+	delete(credsMap, "service_type")
+
+	return nil
+}
+
+// handleValkeyUnbind deletes the per-binding ACL user from the Valkey instance.
+func (b *Broker) handleValkeyUnbind(ctx context.Context, instanceID, bindingID string, details domain.UnbindDetails, logger logger.Logger) error {
+	logger.Info("Processing unbind for Valkey service")
+
+	plan, err := b.FindPlan(details.ServiceID, details.PlanID)
+	if err != nil {
+		logger.Error("Failed to find plan %s/%s: %s", details.ServiceID, details.PlanID, err)
+		return err
+	}
+
+	credMap, err := b.getValkeyCredentials(ctx, instanceID, &plan, logger)
+	if err != nil {
+		return err
+	}
+
+	adminPassword, ok := credMap["admin_password"].(string)
+	if !ok || adminPassword == "" {
+		return ErrValkeyAdminPasswordMissing
+	}
+
+	host, ok := credMap["host"].(string)
+	if !ok || host == "" {
+		return ErrValkeyHostMissing
+	}
+
+	port := 6379
+	if p, ok := credMap["port"].(int); ok && p > 0 {
+		port = p
+	} else if p, ok := credMap["port"].(float64); ok && p > 0 {
+		port = int(p)
+	}
+
+	tlsPort := 0
+	if p, ok := credMap["tls_port"].(int); ok {
+		tlsPort = p
+	} else if p, ok := credMap["tls_port"].(float64); ok {
+		tlsPort = int(p)
+	}
+
+	useTLS := tlsPort > 0
+
+	hosts := ExtractHosts(credMap)
+	if len(hosts) > 0 {
+		return b.deleteValkeyACLUserOnAllNodes(ctx, hosts, port, adminPassword, bindingID, useTLS, tlsPort, logger)
+	}
+
+	return b.deleteValkeyACLUser(ctx, host, port, adminPassword, bindingID, useTLS, tlsPort, logger)
+}
+
+// getValkeyCredentials retrieves the raw credential map for a Valkey instance.
+func (b *Broker) getValkeyCredentials(_ context.Context, instanceID string, plan *services.Plan, logger logger.Logger) (map[string]interface{}, error) {
+	logger.Debug("Retrieving admin credentials for Valkey instance")
+
+	deploymentManifest := b.getDeploymentManifestFromVault(instanceID, logger)
+
+	creds, err := manifest.GetCreds(instanceID, *plan, b.BOSH, deploymentManifest, logger)
+	if err != nil {
+		logger.Error("Failed to retrieve credentials: %s", err)
+		return nil, fmt.Errorf("failed to get Valkey credentials: %w", err)
+	}
+
+	credMap, ok := creds.(map[string]interface{})
+	if !ok {
+		logger.Error("Invalid creds type: %T", creds)
+		return nil, fmt.Errorf("%w: %T", ErrInvalidCredsType, creds)
+	}
+
+	return credMap, nil
+}
+
+// createValkeyACLUser creates a single ACL user on one Valkey node.
+func (b *Broker) createValkeyACLUser(ctx context.Context, host string, port int, adminPassword, username, password string, useTLS bool, tlsPort int, logger logger.Logger) error {
+	logger.Info("Creating Valkey ACL user %s on %s:%d", username, host, port)
+
+	return common.WithRetry(ctx, func() error {
+		client, err := connectToValkeyAdmin(ctx, host, port, adminPassword, useTLS, tlsPort)
+		if err != nil {
+			return fmt.Errorf("%w: connection failed: %w", ErrFailedToCreateValkeyACLUser, err)
+		}
+		defer client.Close()
+
+		// ACL SETUSER <username> on ><password> ~* &* +@all -@admin
+		result := client.Do(ctx, "ACL", "SETUSER", username, "on", ">"+password, "~*", "&*", "+@all", "-@admin")
+		if result.Err() != nil {
+			logger.Error("ACL SETUSER failed: %s", result.Err())
+			return fmt.Errorf("%w: SETUSER: %w", ErrValkeyACLCommandFailed, result.Err())
+		}
+
+		// ACL SAVE to persist
+		saveResult := client.Do(ctx, "ACL", "SAVE")
+		if saveResult.Err() != nil {
+			logger.Error("ACL SAVE failed: %s", saveResult.Err())
+			return fmt.Errorf("%w: SAVE: %w", ErrValkeyACLCommandFailed, saveResult.Err())
+		}
+
+		logger.Debug("Successfully created ACL user %s", username)
+
+		return nil
+	}, valkeyACLRetries, valkeyACLBaseWait)
+}
+
+// createValkeyACLUserOnAllNodes creates the ACL user on every cluster node.
+func (b *Broker) createValkeyACLUserOnAllNodes(ctx context.Context, hosts []string, port int, adminPassword, username, password string, useTLS bool, tlsPort int, logger logger.Logger) error {
+	logger.Info("Creating Valkey ACL user %s on %d cluster nodes", username, len(hosts))
+
+	var errs []string
+
+	for _, host := range hosts {
+		if err := b.createValkeyACLUser(ctx, host, port, adminPassword, username, password, useTLS, tlsPort, logger); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", host, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%w: %s", ErrFailedToCreateValkeyACLUser, strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// deleteValkeyACLUser deletes an ACL user from one Valkey node.
+func (b *Broker) deleteValkeyACLUser(ctx context.Context, host string, port int, adminPassword, username string, useTLS bool, tlsPort int, logger logger.Logger) error {
+	logger.Info("Deleting Valkey ACL user %s on %s:%d", username, host, port)
+
+	return common.WithRetry(ctx, func() error {
+		client, err := connectToValkeyAdmin(ctx, host, port, adminPassword, useTLS, tlsPort)
+		if err != nil {
+			return fmt.Errorf("%w: connection failed: %w", ErrFailedToDeleteValkeyACLUser, err)
+		}
+		defer client.Close()
+
+		result := client.Do(ctx, "ACL", "DELUSER", username)
+		if result.Err() != nil {
+			// User not found is success (idempotent)
+			if strings.Contains(result.Err().Error(), "ERR The user") {
+				logger.Info("ACL user %s does not exist, treating as success", username)
+				return nil
+			}
+
+			logger.Error("ACL DELUSER failed: %s", result.Err())
+
+			return fmt.Errorf("%w: DELUSER: %w", ErrValkeyACLCommandFailed, result.Err())
+		}
+
+		saveResult := client.Do(ctx, "ACL", "SAVE")
+		if saveResult.Err() != nil {
+			logger.Error("ACL SAVE failed: %s", saveResult.Err())
+			return fmt.Errorf("%w: SAVE: %w", ErrValkeyACLCommandFailed, saveResult.Err())
+		}
+
+		logger.Debug("Successfully deleted ACL user %s", username)
+
+		return nil
+	}, valkeyACLRetries, valkeyACLBaseWait)
+}
+
+// deleteValkeyACLUserOnAllNodes deletes the ACL user from every cluster node.
+func (b *Broker) deleteValkeyACLUserOnAllNodes(ctx context.Context, hosts []string, port int, adminPassword, username string, useTLS bool, tlsPort int, logger logger.Logger) error {
+	logger.Info("Deleting Valkey ACL user %s from %d cluster nodes", username, len(hosts))
+
+	var errs []string
+
+	for _, host := range hosts {
+		if err := b.deleteValkeyACLUser(ctx, host, port, adminPassword, username, useTLS, tlsPort, logger); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", host, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%w: %s", ErrFailedToDeleteValkeyACLUser, strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// connectToValkeyAdmin creates a short-lived Redis client authenticated as the
+// default (admin) user. The caller is responsible for closing the client.
+func connectToValkeyAdmin(ctx context.Context, host string, port int, adminPassword string, useTLS bool, tlsPort int) (*redis.Client, error) {
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	opts := &redis.Options{
+		Addr:         addr,
+		Password:     adminPassword,
+		DB:           0,
+		DialTimeout:  valkeyDialTimeout,
+		ReadTimeout:  valkeyOpTimeout,
+		WriteTimeout: valkeyOpTimeout,
+	}
+
+	if useTLS && tlsPort > 0 {
+		opts.Addr = fmt.Sprintf("%s:%d", host, tlsPort)
+		opts.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 - Internal BOSH network
+			ServerName:         host,
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
+
+	client := redis.NewClient(opts)
+
+	pingCtx, cancel := context.WithTimeout(ctx, valkeyDialTimeout)
+	defer cancel()
+
+	if err := client.Ping(pingCtx).Err(); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("Valkey ping failed at %s: %w", opts.Addr, err)
+	}
+
+	return client, nil
+}
+
+// ExtractHosts returns the list of cluster node IPs from the credential map,
+// or nil for standalone instances. Exported for testing.
+func ExtractHosts(credMap map[string]interface{}) []string {
+	hostsRaw, ok := credMap["hosts"]
+	if !ok {
+		return nil
+	}
+
+	switch v := hostsRaw.(type) {
+	case []interface{}:
+		hosts := make([]string, 0, len(v))
+
+		for _, h := range v {
+			if s, ok := h.(string); ok {
+				hosts = append(hosts, s)
+			}
+		}
+
+		if len(hosts) > 0 {
+			return hosts
+		}
+	case []string:
+		if len(v) > 0 {
+			return v
+		}
+	}
+
+	return nil
+}

--- a/internal/broker/valkey_test.go
+++ b/internal/broker/valkey_test.go
@@ -1,0 +1,75 @@
+package broker_test
+
+import (
+	"blacksmith/internal/broker"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Valkey ACL Credentials", func() {
+	Describe("isValkeyService", func() {
+		It("returns true for maps with service_type valkey", func() {
+			credMap := map[string]interface{}{
+				"host":           "10.0.0.5",
+				"port":           6379,
+				"password":       "secret",
+				"admin_password": "secret",
+				"username":       "default",
+				"service_type":   "valkey",
+			}
+			Expect(broker.IsValkeyService(credMap)).To(BeTrue())
+		})
+
+		It("returns false for maps without service_type", func() {
+			credMap := map[string]interface{}{
+				"host":     "10.0.0.5",
+				"port":     6379,
+				"password": "secret",
+			}
+			Expect(broker.IsValkeyService(credMap)).To(BeFalse())
+		})
+
+		It("returns false for non-valkey service_type", func() {
+			credMap := map[string]interface{}{
+				"host":         "10.0.0.5",
+				"port":         5672,
+				"service_type": "rabbitmq",
+			}
+			Expect(broker.IsValkeyService(credMap)).To(BeFalse())
+		})
+
+		It("returns false for non-string service_type", func() {
+			credMap := map[string]interface{}{
+				"service_type": 42,
+			}
+			Expect(broker.IsValkeyService(credMap)).To(BeFalse())
+		})
+	})
+
+	Describe("extractHosts", func() {
+		It("returns nil for standalone credentials without hosts", func() {
+			credMap := map[string]interface{}{
+				"host": "10.0.0.5",
+				"port": 6379,
+			}
+			Expect(broker.ExtractHosts(credMap)).To(BeNil())
+		})
+
+		It("returns host list for cluster credentials", func() {
+			credMap := map[string]interface{}{
+				"host":  "10.0.0.5",
+				"hosts": []interface{}{"10.0.0.5", "10.0.0.6", "10.0.0.7"},
+				"port":  6379,
+			}
+			Expect(broker.ExtractHosts(credMap)).To(Equal([]string{"10.0.0.5", "10.0.0.6", "10.0.0.7"}))
+		})
+
+		It("returns nil for empty hosts list", func() {
+			credMap := map[string]interface{}{
+				"host":  "10.0.0.5",
+				"hosts": []interface{}{},
+			}
+			Expect(broker.ExtractHosts(credMap)).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Valkey bindings currently hand out the shared admin password, so
revoking one tenant means rotating every tenant. This PR creates a
per-binding ACL user on `Bind` and deletes it on `Unbind`, giving
each binding its own credentials with no access to admin commands.

- New `internal/broker/valkey.go` handles ACL create/delete against
  both standalone instances and clusters (fan-out to all nodes).
- Uses short-lived `go-redis` clients with TLS support, retry via
  `common.WithRetry`, and `ACL SAVE` to persist to the aclfile.
- Broker `Bind`/`Unbind` and the `GetBindingCredentials` dynamic
  path now route Valkey credentials through the new helpers.
- `service_type` is stripped from returned credentials alongside
  the existing admin-field filtering.
- ACL user grants: `~* &* +@all -@admin` (full data access, no
  administrative commands).
- Dynamic username = bindingID (UUID); password = fresh UUID.

## Test plan

- [ ] Unit tests for `IsValkeyService` and `ExtractHosts` helpers
      (`valkey_test.go`) pass
- [ ] `go build ./...` and `go test ./...` clean
- [ ] Standalone Valkey: bind, verify `ACL LIST` shows the new
      user, connect with returned creds, verify admin commands
      are rejected
- [ ] Standalone Valkey: unbind, verify `ACL LIST` no longer
      shows the user
- [ ] Cluster Valkey: bind, verify the ACL user exists on every
      node, verify connection works through any node
- [ ] Cluster Valkey: unbind, verify the ACL user is removed
      from every node
- [ ] TLS-enabled Valkey: bind/unbind against the TLS port
- [ ] Failure path: bind with one cluster node unreachable —
      confirm the error surfaces and the operator can retry
- [ ] Rebind an existing binding — confirm idempotent behavior
      (DELUSER is naturally idempotent; SETUSER overwrites)

