### PR TITLE
Wrap VerifyMount in withAutoUnseal

### DIFF
--- a/internal/vault/auto_unseal.go
+++ b/internal/vault/auto_unseal.go
@@ -232,6 +232,11 @@ func (vault *Vault) SetAutoUnsealHook(hook func(context.Context) error) {
 	vault.autoUnsealHook = hook
 }
 
+// SetVerifyMountFn overrides the VerifyMount implementation for testing.
+func (vault *Vault) SetVerifyMountFn(fn func(store string, createIfMissing bool) error) {
+	vault.verifyMountFn = fn
+}
+
 // WithAutoUnseal is a public wrapper for testing purposes.
 func (vault *Vault) WithAutoUnseal(ctx context.Context, operation func() error) error {
 	return vault.withAutoUnseal(ctx, operation)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -33,6 +33,8 @@ type Vault struct {
 	autoUnsealEnabled bool
 	// test hook: if set, used by withAutoUnseal instead of AutoUnsealIfSealed
 	autoUnsealHook func(context.Context) error
+	// test hook: if set, called by VerifyMount instead of client.VerifyMount
+	verifyMountFn func(store string, createIfMissing bool) error
 	// HTTP timeout for vault client (0 uses default)
 	httpTimeout time.Duration
 }
@@ -382,7 +384,16 @@ func (vault *Vault) VerifyMount(store string, createIfMissing bool) error {
 		return err
 	}
 
-	err = vault.client.VerifyMount(store, createIfMissing)
+	verifyFn := vault.verifyMountFn
+	if verifyFn == nil {
+		verifyFn = func(s string, c bool) error {
+			return vault.client.VerifyMount(s, c)
+		}
+	}
+
+	err = vault.withAutoUnseal(context.Background(), func() error {
+		return verifyFn(store, createIfMissing)
+	})
 	if err != nil {
 		logger.Error("failed to verify mount %s: %s", store, err)
 

--- a/internal/vault/vault_suite_test.go
+++ b/internal/vault/vault_suite_test.go
@@ -1,0 +1,14 @@
+package vault_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVault(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vault Suite")
+}

--- a/internal/vault/verify_mount_test.go
+++ b/internal/vault/verify_mount_test.go
@@ -1,0 +1,38 @@
+package vault_test
+
+import (
+	"context"
+
+	"blacksmith/internal/vault"
+	"github.com/hashicorp/vault/api"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Vault VerifyMount", func() {
+	Context("auto-unseal retry on sealed vault", func() {
+		It("retries VerifyMount once after auto-unseal succeeds", func() {
+			v := vault.New("http://127.0.0.1:8200", "test-token", false)
+
+			unsealed := false
+			v.SetAutoUnsealEnabled(true)
+			v.SetAutoUnsealHook(func(_ context.Context) error {
+				unsealed = true
+				return nil
+			})
+
+			calls := 0
+			v.SetVerifyMountFn(func(store string, createIfMissing bool) error {
+				calls++
+				if !unsealed {
+					return &api.ResponseError{StatusCode: 503, Errors: []string{"sealed"}}
+				}
+				return nil
+			})
+
+			err := v.VerifyMount("secret", true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(2), "VerifyMount should be called twice: once sealed, once after unseal")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes a regression introduced in commit 5dcf05d (Sep 24 2025, "fix RMQ broker rapid sequencing bug") that causes the broker to silently come up without a `secret/` KV-v2 mount on any cold-start where `vault.db` is absent. Provisioning then fails for the lifetime of the broker process with `failed to track service request in Vault`.

The fix wraps `VerifyMount` in `withAutoUnseal` — the same retry-after-unseal pattern already used by `Get` / `Put` / `Delete`.

## The bug

On a cold-start with no persistent `vault.db`:

1. `Init()` (`internal/vault/vault.go`) takes the fresh-init branch: calls `sys/init`, writes `seal_key` + `root_token` to `/var/vcap/store/blacksmith/.vault/creds`, and sets the in-memory token. It does **not** call `Unseal()`.
2. `verifySecretMount` (`main.go`) runs synchronously immediately after, calls `VerifyMount("secret", true)`.
3. `client.VerifyMount` calls `Sys().ListMounts()`. Vault is still sealed → 503.
4. The error propagates up. `main.go:verifySecretMount` logs it and continues (since 5dcf05d removed the `log.Fatal`).
5. ~15 seconds later, `StartHealthWatcher`'s ticker fires `AutoUnsealIfSealed`. Vault is now unsealed — but nothing ever calls `VerifyMount` again. The mount is never created.

Before 5dcf05d, the `log.Fatal` on `VerifyMount` failure crashed the broker. BPM restarted it, the second startup ran `VerifyMount` against the now-unsealed Vault, and the mount got created. The crash-and-restart was the implicit retry that made cold-starts work.

## Affected versions

| Tag | Status |
|---|---|
| v1.0.0 – v1.0.13 | clean (`log.Fatal` self-heals) |
| v1.1.0, v1.2.0, v1.2.1, v1.3.0 | **affected** |

## Why this hasn't been reported widely

Three masks hide it in normal operation:

1. **Existing installs first-deployed on v1.0.x.** The mount got created via the old crash-loop path; persistent disks preserve it through every subsequent upgrade.
2. **Persistent disks survive normal lifecycle ops.** `bosh restart` / `bosh recreate` / `genesis deploy` / stemcell upgrades all preserve the disk and the mount.
3. **`monit restart blacksmith` papers it over.** On a manual restart, Vault is already unsealed, so `verifySecretMount` succeeds and creates the mount. Most operators do this reflexively without realizing they triggered the bug.

The bug only surfaces on a **true cold-start** — `bosh delete-deployment` + redeploy, or first-ever deploy of a new foundation — combined with no operator restart afterward.

## Reproducer (against blacksmith-bosh-release v2.2.0)

```bash
# Deploy upstream stable
bosh upload-release https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v2.2.0/blacksmith-2.2.0.tgz
# (deploy via your usual mechanism)

# Trigger cold-start: destroy persistent disk
bosh delete-deployment -d <name>
bosh disks --orphaned   # find the blacksmith disk CID(s)
bosh delete-disk <CID>  # for each orphan (do NOT use clean-up --all)
# (redeploy)

# Provisioning is now silently broken
cf create-service redis cache-small repro-test
# Job (...) failed: provision could not be completed:
#   Service broker error: failed to track service request in Vault
```

`/b/status` reports the broker as healthy (`bosh: connected, vault: connected`) — the failure is only on writes that need the missing `secret/` mount.

## Fix

```diff
diff --git a/internal/vault/vault.go b/internal/vault/vault.go
@@ -382,7 +384,16 @@ func (vault *Vault) VerifyMount(store string, createIfMissing bool) error {
     return err
   }

-  err = vault.client.VerifyMount(store, createIfMissing)
+  verifyFn := vault.verifyMountFn
+  if verifyFn == nil {
+    verifyFn = func(s string, c bool) error {
+      return vault.client.VerifyMount(s, c)
+    }
+  }
+
+  err = vault.withAutoUnseal(context.Background(), func() error {
+    return verifyFn(store, createIfMissing)
+  })
   if err != nil {
     logger.Error("failed to verify mount %s: %s", store, err)
```

The `verifyMountFn` test hook mirrors the existing `autoUnsealHook` pattern and is needed because `client.VerifyMount` talks to a real Vault SDK that's hard to fake in unit tests.

## Test

`internal/vault/verify_mount_test.go` — Ginkgo spec that:

1. Replaces `verifyMountFn` with a counter-incrementing fake that returns `*api.ResponseError{StatusCode: 503}` on the first call and nil afterwards.
2. Sets `autoUnsealEnabled = true` and provides a no-op `autoUnsealHook` that flips a boolean.
3. Calls `vault.VerifyMount("secret", true)`.
4. Asserts: error is nil, `verifyMountFn` was called exactly twice (once sealed, once after auto-unseal).

Also adds `internal/vault/vault_suite_test.go` — a Ginkgo v1 bootstrap. The package previously had `auto_unseal_test.go` with 4 specs that were silently skipped because no `TestXxx` runner existed; this PR activates those as well.

`make test` — all packages pass, zero failures. The `internal/vault` suite now reports 5 specs.

## Empirical fix proof

Validated end-to-end on a real BOSH foundation. Same cold-start procedure as the reproducer above, run against v2.2.0 (fails) and against this PR's broker (succeeds). Smoking-gun broker log slice from the v2.2.0+fix run, 7ms window:

```
Vault is sealed
11:28:08.030  [vault auto-unseal] vault is sealed; attempting auto-unseal
11:28:08.032  [vault unseal] checking current seal status of the vault
11:28:08.032  [vault unseal] vault is sealed; unsealing it
11:28:08.037  [vault unseal] unsealed the vault
11:28:08.037  [vault auto-unseal] vault auto-unseal successful
11:28:08.037  [Verify Mount] checking vault has the secret mount created   <- retry firing
```

Lines 2-7 are exactly what `withAutoUnseal` does. Without this PR, those lines never appear and the broker continues with no mount.

## Suggested release

Worth considering a `v1.3.1` hotfix — the bug silently bricks any blacksmith broker after a `bosh delete-deployment` cycle, and the workaround (manual `monit restart blacksmith` after Vault auto-unseals, or operator SSH'ing in to `vault secrets enable -path=secret -version=2 kv`) requires direct VM access and isn't documented anywhere.

## Files changed

- `internal/vault/vault.go` — wrap call site, add test hook field
- `internal/vault/auto_unseal.go` — `SetVerifyMountFn` setter
- `internal/vault/verify_mount_test.go` — new regression test
- `internal/vault/vault_suite_test.go` — new Ginkgo v1 bootstrap
